### PR TITLE
feat: exercise progression chart + workout history detail (#10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,15 @@ An iOS app for logging workouts directly into your [Obsidian](https://obsidian.m
 
 ## What it does
 
-WorkoutMD reads workout templates from your vault, lets you track sets and reps during a session, and writes the completed workout back as a markdown file — keeping your fitness data inside your Obsidian notes.
+WorkoutMD reads workout templates from your vault, lets you track sets and reps during a live session, and writes the completed session back as a dated markdown file — keeping all fitness data inside your Obsidian notes.
 
-- Pick a workout template (e.g. `chest`, `back`, `legs`) from your vault's `templates/` folder
-- Log sets, reps, and weight for each exercise
-- Save the session as a dated markdown file in your vault's `workouts/` folder
-- Hike/cardio sessions and video exercise demos are also supported
-- Daily journal entries are linked via wikilinks in the YAML frontmatter
+- Pick one or more workout templates from your vault's `templates/` folder (multi-select for combo sessions)
+- Log sets, reps, and weight for each exercise; weights are pre-filled from the previous session
+- Save the session: writes a workout file, updates the daily journal, and persists last-used weights
+- Tap any exercise name to see a weight-over-time progression chart (Swift Charts)
+- Browse session history in the Overview tab; tap a past workout to see the full set log
+- Hike/cardio and recovery session types are also supported
+- Exercise demo videos can be attached to template entries and played in-app
 
 ## Requirements
 
@@ -22,19 +24,131 @@ WorkoutMD reads workout templates from your vault, lets you track sets and reps 
 
 ```
 WorkoutMD/
-├── generate_xcodeproj.py   # Regenerate the Xcode project after adding Swift files
-├── WorkoutMD/              # Swift source files
-│   ├── Models/             # Exercise, WorkoutSet, WorkoutTemplate
-│   ├── Views/              # SwiftUI views
-│   ├── Services/           # VaultService, MarkdownParser, MarkdownWriter
-│   └── Settings/           # SettingsView
-└── WorkoutMD.xcodeproj/    # Generated Xcode project
+├── generate_xcodeproj.py          # Regenerate Xcode project after adding Swift files
+├── WorkoutMD/                     # Swift source root
+│   ├── WorkoutMDApp.swift         # @main entry point; injects VaultService
+│   ├── ContentView.swift          # Root TabView (Home + Overview tabs)
+│   ├── Models/
+│   │   ├── Exercise.swift         # ObservableObject; mutable during a session
+│   │   ├── WorkoutSet.swift       # Value type; one logged set (weight, reps, isDone)
+│   │   ├── WorkoutTemplate.swift  # Loaded from a template file; owns [Exercise]
+│   │   └── LastWeight.swift       # Codable; persisted weight/reps per exercise name
+│   ├── Views/
+│   │   ├── TemplatePickerView.swift       # Home tab: grid of template cards → start session
+│   │   ├── WorkoutSessionView.swift       # Live session: exercise list, timers, save flow
+│   │   ├── ExerciseCardView.swift         # One exercise section with its sets + header
+│   │   ├── SetRowView.swift               # One set row: weight field, reps stepper, done toggle
+│   │   ├── HikeSessionView.swift          # Cardio session entry: distance + time
+│   │   ├── RecoverySessionView.swift      # Recovery session entry: type picker
+│   │   ├── OverviewView.swift             # History tab: workouts grouped by week
+│   │   ├── WorkoutDetailView.swift        # Past workout detail: exercises + sets
+│   │   ├── ExerciseProgressionView.swift  # Swift Charts sheet: max weight over time
+│   │   ├── VideoPlayerView.swift          # AVPlayer sheet for exercise demo videos
+│   │   └── VaultSetupView.swift           # Shown on first launch to pick vault folder
+│   ├── Services/
+│   │   ├── VaultService.swift     # File I/O, security-scoped bookmarks, last-weights store
+│   │   ├── MarkdownParser.swift   # Template parser + history (set) parser
+│   │   └── MarkdownWriter.swift   # Produces all markdown output (frontmatter, body, filenames)
+│   └── Settings/
+│       └── SettingsView.swift     # Folder name overrides (journals, templates, workouts)
+└── WorkoutMD.xcodeproj/           # Generated Xcode project (do not edit by hand)
 
 sample_data/
-├── journals/               # Example daily journal entry
-├── templates/              # Example workout templates
-└── videos/                 # Placeholder for exercise demo videos
+├── journals/                      # Example daily journal entry
+├── templates/                     # Example workout templates
+└── videos/                        # Placeholder for exercise demo videos
 ```
+
+## Architecture
+
+### Layers
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  Views  (SwiftUI, read models via @ObservedObject /      │
+│          @EnvironmentObject; no direct file I/O)         │
+├─────────────────────────────────────────────────────────┤
+│  Models  (Exercise, WorkoutSet, WorkoutTemplate,          │
+│           LastWeight — pure data, no I/O)                │
+├─────────────────────────────────────────────────────────┤
+│  Services  (VaultService, MarkdownParser,                 │
+│             MarkdownWriter — all I/O is here)            │
+└─────────────────────────────────────────────────────────┘
+```
+
+### Models
+
+| Type | Kind | Notes |
+|------|------|-------|
+| `Exercise` | `class`, `ObservableObject` | Mutable during a session; `@Published var sets` so `ExerciseCardView` reacts to changes |
+| `WorkoutSet` | `struct`, `Codable` | Value type — weight (String), reps (Int), isDone (Bool) |
+| `WorkoutTemplate` | `struct` | Loaded once from disk at picker time; owns a copy of `[Exercise]` |
+| `LastWeight` | `struct`, `Codable` | Serialized to `.obsidian/last-weights.json` in the vault; keyed by exercise name |
+
+`Exercise` is a **class** rather than a struct because `ForEach($exercise.sets)` in `ExerciseCardView` requires a stable reference to drive `@ObservedObject` reactivity as individual sets change.
+
+### Services
+
+**`VaultService`** (`@MainActor`, `ObservableObject`)
+- Holds a security-scoped bookmark to the vault folder (persisted in `UserDefaults`)
+- Exposes synchronous helpers for the main thread: `readFile`, `writeFile`, `fileExists`, `listFiles`
+- Exposes `withVaultURL(_:)` — a `nonisolated async` wrapper that runs file I/O on a background `Task.detached` thread, used for all save operations in `WorkoutSessionView`
+- Stores user-configurable folder names (`journalsFolder`, `templatesFolder`, `workoutsFolder`) in `UserDefaults`
+- Owns `readLastWeights()` / `writeLastWeights(_:)` for the JSON weight-persistence sidecar
+
+**`MarkdownParser`** (`struct`)
+- `parseTemplate(_:relativeTo:)` — reads a template file (`w-*-t.md`) into `[Exercise]`; top-level `- Name` lines become exercises, indented `- [video](path)` lines attach a video URL
+- `parseSets(from:forExercise:)` — reads a saved workout file, finds a `### Exercise` section, and returns all `[x]`/`[ ]` set lines as `[ParsedSet]`; used by `ExerciseProgressionView` to build chart data
+
+**`MarkdownWriter`** (`struct`)
+- Produces all markdown text: frontmatter (workout, hike, recovery), body serialization, daily note embed
+- Owns filename generation: `workoutFilename(sessionName:date:)` (ISO date + slug) and `dailyNoteFilename(for:)` (Obsidian `yyyy-MMM-dd` convention)
+- `muscleGroups(from:)` — maps a session name like `"Back + Abs"` to muscle-group tags for the frontmatter
+
+### Views & navigation
+
+```
+ContentView (TabView)
+├── Tab: Home
+│   NavigationStack
+│   └── TemplatePickerView
+│       ├── → WorkoutSessionView        (navigationDestination)
+│       │     ExerciseCardView (per exercise)
+│       │       SetRowView (per set)
+│       │       ExerciseProgressionView (sheet, tapping exercise name)
+│       ├── → HikeSessionView           (navigationDestination)
+│       └── → RecoverySessionView       (navigationDestination)
+│
+└── Tab: Overview
+    NavigationStack
+    └── OverviewView
+        └── → WorkoutDetailView         (NavigationLink)
+              ExerciseProgressionView   (sheet, tapping exercise name)
+```
+
+`VaultService` is injected at the root as an `@EnvironmentObject` and flows down the entire tree.
+
+### Data flow: starting a session
+
+1. `TemplatePickerView.loadTemplates()` reads `templates/w-*-t.md` files via `VaultService.readFile`, parses them with `MarkdownParser.parseTemplate`, and stores them in `@State var templates`.
+2. User selects one or more cards; tapping **Start Workout** pushes `WorkoutSessionView(templates:)`.
+3. `WorkoutSessionView.onAppear` flattens all template exercises into `@State var exercises` and pre-fills each exercise's first set from `VaultService.readLastWeights()`.
+
+### Data flow: saving a session
+
+All four writes happen inside a single `VaultService.withVaultURL` call (background thread):
+
+1. **Workout file** — `MarkdownWriter.workoutFrontmatter` + `serializeWorkout` → `workouts/yyyy-MM-dd-slug.md`
+2. **Daily note** — read existing or fall back to `journal-t.md` template → `MarkdownWriter.appendEmbedIfNeeded` → `journals/yyyy-MMM-dd.md`
+3. **Last-weights sidecar** — updated `LastWeightsStore` encoded to JSON → `.obsidian/last-weights.json`
+
+### Data flow: exercise progression chart
+
+`ExerciseProgressionView` scans every file in `workouts/` on load:
+1. `VaultService.listFiles` returns all `.md` filenames, sorted.
+2. For each file, `MarkdownParser.parseSets(from:forExercise:)` extracts sets for the named exercise.
+3. The max weight across all sets in a file becomes one `ExerciseDataPoint`.
+4. Points are sorted by date and plotted with Swift Charts (`LineMark` + `PointMark`).
 
 ## Building
 
@@ -42,7 +156,7 @@ sample_data/
 2. Open `WorkoutMD/WorkoutMD.xcodeproj` in Xcode
 3. Select your target device or simulator and run
 
-> If you add or remove Swift source files, regenerate the Xcode project:
+> If you add or remove Swift source files, update the UUID map and `SWIFT_FILES` list in `generate_xcodeproj.py`, then regenerate:
 > ```bash
 > cd WorkoutMD/
 > python3 generate_xcodeproj.py
@@ -50,15 +164,15 @@ sample_data/
 
 ## Vault setup
 
-On first launch the app will ask you to select your vault folder. It stores a security-scoped bookmark so it can access the folder across app launches without prompting again.
+On first launch the app shows a folder picker. It stores a security-scoped bookmark so it can access the vault across app launches without prompting again.
 
 Configure the folder names used inside your vault from the Settings screen (defaults: `journals`, `templates`, `workouts`).
 
-## File format
+## File formats
 
 ### Workout template (`templates/w-chest-t.md`)
 
-Filename convention: `w-{slug}-t.md`. Only files matching this pattern are shown in the template picker.
+Filename convention: `w-{slug}-t.md`. Only files matching this pattern appear in the picker.
 
 ```
 - Chest press
@@ -71,7 +185,7 @@ Top-level `- Name` lines become exercises. Indented `  - [video](path)` lines at
 
 ### Completed workout (`workouts/2026-02-13-chest.md`)
 
-Filename: `yyyy-MM-dd-{slug}.md` (ISO date, then slugified session name).
+Filename: `yyyy-MM-dd-{slug}.md`.
 
 ```markdown
 ---
@@ -81,9 +195,11 @@ categories:
 muscles:
   - "[[chest]]"
 effort: 7
+duration: 45
 ---
 
 ## Chest — Feb 13, 2026
+- Duration: 45m
 
 ### Chest press
 - [x] 135 × 10
@@ -91,12 +207,11 @@ effort: 7
 - [ ] bodyweight × 10
 ```
 
-Frontmatter fields: `date` (ISO), `categories`, `muscles` (list of `[[muscle]]` wikilinks), `effort` (integer 0–10).
-Body: `## {session} — {date}`, then `### {exercise}`, then `- [x/[ ]] weight × reps` (weight is `bodyweight` when empty).
+`effort` is 0–10 (set at save time). `duration` is total elapsed minutes. Weight is `bodyweight` when the field is empty.
 
 ### Hike (`workouts/2026-02-13-hike.md`)
 
-Same frontmatter shape plus optional `distance` and `time` (minutes) fields. Muscles default to quads/hams/glutes.
+Same frontmatter shape plus optional `distance` (string) and `time` (integer minutes).
 
 ```markdown
 ---
@@ -118,9 +233,22 @@ time: 75
 - Time: 1h 15m
 ```
 
+### Recovery session (`workouts/2026-02-13-recovery.md`)
+
+```markdown
+---
+date: 2026-02-13
+categories:
+  - "[[workouts]]"
+type: recovery
+---
+
+## Yoga — Feb 13, 2026
+```
+
 ### Daily journal (`journals/2026-Feb-13.md`)
 
-Filename: `yyyy-MMM-dd.md` (Obsidian convention — three-letter month, NOT ISO).
+Filename uses Obsidian's `yyyy-MMM-dd` convention (three-letter month, not ISO).
 
 ```markdown
 ---
@@ -136,16 +264,18 @@ habits:
 ![[workouts/2026-02-13-chest]]
 ```
 
-The app appends an embed line (`![[workouts/…]]`) to the daily note after saving a workout.
+After each save the app appends an `![[workouts/…]]` embed to the daily note (or creates it from `journal-t.md` if it doesn't exist yet).
 
-## Architecture
+### Last-weights sidecar (`.obsidian/last-weights.json`)
 
-| Layer | Files |
-|-------|-------|
-| App entry | `WorkoutMDApp.swift`, `ContentView.swift` |
-| Models | `Exercise`, `WorkoutSet`, `WorkoutTemplate` |
-| Views | `TemplatePickerView`, `WorkoutSessionView`, `HikeSessionView`, `ExerciseCardView`, `SetRowView`, `VideoPlayerView`, `VaultSetupView`, `SettingsView` |
-| Services | `VaultService` (file I/O + bookmarks), `MarkdownParser`, `MarkdownWriter` |
+Stored inside the vault so weights follow the vault across devices. Format:
+
+```json
+{
+  "Chest press": { "reps": 8, "updatedAt": "2026-02-13", "weight": "135" },
+  "Incline push-ups": { "reps": 10, "updatedAt": "2026-02-13", "weight": "" }
+}
+```
 
 ## License
 

--- a/WorkoutMD/WorkoutMD/Views/ExerciseCardView.swift
+++ b/WorkoutMD/WorkoutMD/Views/ExerciseCardView.swift
@@ -5,6 +5,7 @@ struct ExerciseCardView: View {
     var onRemove: (() -> Void)? = nil
     var onSetDone: (() -> Void)? = nil
     @State private var showingVideo = false
+    @State private var showingProgression = false
 
     var body: some View {
         Section {
@@ -20,10 +21,15 @@ struct ExerciseCardView: View {
             }
         } header: {
             HStack {
-                Text(exercise.name)
-                    .font(.headline)
-                    .foregroundStyle(.primary)
-                    .textCase(nil)
+                Button {
+                    showingProgression = true
+                } label: {
+                    Text(exercise.name)
+                        .font(.headline)
+                        .foregroundStyle(.primary)
+                        .textCase(nil)
+                }
+                .buttonStyle(.plain)
                 Spacer()
                 if exercise.videoURL != nil {
                     Button {
@@ -47,6 +53,11 @@ struct ExerciseCardView: View {
         .sheet(isPresented: $showingVideo) {
             if let url = exercise.videoURL {
                 VideoPlayerView(url: url)
+            }
+        }
+        .sheet(isPresented: $showingProgression) {
+            NavigationStack {
+                ExerciseProgressionView(exerciseName: exercise.name)
             }
         }
     }

--- a/WorkoutMD/WorkoutMD/Views/ExerciseProgressionView.swift
+++ b/WorkoutMD/WorkoutMD/Views/ExerciseProgressionView.swift
@@ -1,0 +1,66 @@
+import SwiftUI
+import Charts
+
+struct ExerciseDataPoint: Identifiable {
+    var id = UUID()
+    var date: Date
+    var maxWeight: Double
+}
+
+struct ExerciseProgressionView: View {
+    let exerciseName: String
+    @EnvironmentObject var vaultService: VaultService
+    @State private var dataPoints: [ExerciseDataPoint] = []
+    @State private var isLoading = true
+
+    var body: some View {
+        Group {
+            if isLoading {
+                ProgressView()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else if dataPoints.isEmpty {
+                ContentUnavailableView(
+                    "No weight data",
+                    systemImage: "chart.line.uptrend.xyaxis",
+                    description: Text("Complete a session with numeric weights to see progression.")
+                )
+            } else {
+                Chart(dataPoints) { pt in
+                    LineMark(
+                        x: .value("Date", pt.date),
+                        y: .value("Weight", pt.maxWeight)
+                    )
+                    PointMark(
+                        x: .value("Date", pt.date),
+                        y: .value("Weight", pt.maxWeight)
+                    )
+                }
+                .padding()
+            }
+        }
+        .navigationTitle(exerciseName)
+        .navigationBarTitleDisplayMode(.inline)
+        .task { await load() }
+    }
+
+    @MainActor
+    private func load() async {
+        isLoading = true
+        defer { isLoading = false }
+        let folder = vaultService.workoutsFolder
+        guard let files = try? vaultService.listFiles(inFolder: folder, matching: { $0.hasSuffix(".md") }) else { return }
+        let parser = MarkdownParser()
+        let dateFmt = DateFormatter()
+        dateFmt.dateFormat = "yyyy-MM-dd"
+        var points: [ExerciseDataPoint] = []
+        for fileName in files {
+            guard fileName.count > 10,
+                  let date = dateFmt.date(from: String(fileName.prefix(10))),
+                  let text = try? vaultService.readFile(relativePath: "\(folder)/\(fileName)") else { continue }
+            let weights = parser.parseSets(from: text, forExercise: exerciseName).compactMap { $0.weight }
+            guard let maxWeight = weights.max() else { continue }
+            points.append(ExerciseDataPoint(date: date, maxWeight: maxWeight))
+        }
+        dataPoints = points.sorted { $0.date < $1.date }
+    }
+}

--- a/WorkoutMD/WorkoutMD/Views/OverviewView.swift
+++ b/WorkoutMD/WorkoutMD/Views/OverviewView.swift
@@ -28,7 +28,13 @@ struct OverviewView: View {
                     ForEach(grouped, id: \.label) { section in
                         Section(section.label) {
                             ForEach(section.items) { workout in
-                                WorkoutHistoryRow(workout: workout)
+                                NavigationLink(destination: WorkoutDetailView(
+                                    fileName: workout.fileName,
+                                    displayName: workout.displayName,
+                                    date: workout.date
+                                )) {
+                                    WorkoutHistoryRow(workout: workout)
+                                }
                             }
                         }
                     }

--- a/WorkoutMD/WorkoutMD/Views/WorkoutDetailView.swift
+++ b/WorkoutMD/WorkoutMD/Views/WorkoutDetailView.swift
@@ -1,0 +1,112 @@
+import SwiftUI
+
+struct WorkoutDetailView: View {
+    let fileName: String
+    let displayName: String
+    let date: Date
+
+    @EnvironmentObject var vaultService: VaultService
+    @State private var exercises: [PastExercise] = []
+    @State private var selectedExercise: SelectedExerciseName? = nil
+    @State private var isLoading = true
+
+    var body: some View {
+        Group {
+            if isLoading {
+                ProgressView()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else if exercises.isEmpty {
+                ContentUnavailableView(
+                    "No exercises found",
+                    systemImage: "doc.text",
+                    description: Text("This file has no logged exercises.")
+                )
+            } else {
+                List {
+                    ForEach(exercises) { ex in
+                        Section {
+                            ForEach(ex.sets, id: \.self) { setLine in
+                                Text(setLine)
+                                    .font(.body)
+                            }
+                        } header: {
+                            Button {
+                                selectedExercise = SelectedExerciseName(name: ex.name)
+                            } label: {
+                                Text(ex.name)
+                                    .font(.headline)
+                                    .foregroundStyle(.primary)
+                                    .textCase(nil)
+                            }
+                            .buttonStyle(.plain)
+                        }
+                    }
+                }
+                .listStyle(.insetGrouped)
+            }
+        }
+        .navigationTitle(displayName)
+        .navigationBarTitleDisplayMode(.inline)
+        .sheet(item: $selectedExercise) { sel in
+            NavigationStack {
+                ExerciseProgressionView(exerciseName: sel.name)
+            }
+        }
+        .task { await load() }
+    }
+
+    @MainActor
+    private func load() async {
+        isLoading = true
+        defer { isLoading = false }
+        let folder = vaultService.workoutsFolder
+        guard let text = try? vaultService.readFile(relativePath: "\(folder)/\(fileName)") else { return }
+        exercises = parseExercises(from: text)
+    }
+
+    private func parseExercises(from text: String) -> [PastExercise] {
+        var result: [PastExercise] = []
+        var currentName: String? = nil
+        var currentSets: [String] = []
+
+        func flush() {
+            if let name = currentName {
+                result.append(PastExercise(name: name, sets: currentSets))
+            }
+        }
+
+        for line in text.components(separatedBy: "\n") {
+            if line.hasPrefix("### ") {
+                flush()
+                currentName = String(line.dropFirst(4)).trimmingCharacters(in: .whitespaces)
+                currentSets = []
+            } else if line.hasPrefix("## ") {
+                flush()
+                currentName = nil
+                currentSets = []
+            } else if currentName != nil, line.hasPrefix("- [") {
+                guard let bracketOpen = line.firstIndex(of: "["),
+                      let bracketClose = line.firstIndex(of: "]"),
+                      line.index(after: bracketClose) < line.endIndex else { continue }
+                let isDone = line[line.index(after: bracketOpen)] == "x"
+                let content = String(line[line.index(bracketClose, offsetBy: 2)...]).trimmingCharacters(in: .whitespaces)
+                currentSets.append(isDone ? "\(content) ✓" : content)
+            }
+        }
+        flush()
+        return result
+    }
+}
+
+// MARK: - Local models
+
+private struct PastExercise: Identifiable {
+    let id = UUID()
+    let name: String
+    let sets: [String]
+}
+
+private struct SelectedExerciseName: Identifiable {
+    let id = UUID()
+    let name: String
+}

--- a/WorkoutMD/generate_xcodeproj.py
+++ b/WorkoutMD/generate_xcodeproj.py
@@ -52,6 +52,8 @@ U = {
     "FR_OVERVIEW":          "22222222222222222222221C",
     "FR_RECOVERY":          "22222222222222222222221D",
     "FR_LASTWEIGHT":        "22222222222222222222221E",
+    "FR_EXERCISE_PROGRESSION": "22222222222222222222221F",
+    "FR_WORKOUT_DETAIL":       "222222222222222222222220",
     # BuildFile UUIDs (one per source file)
     "BF_APP":               "33333333333333333333330A",
     "BF_CONTENT":           "33333333333333333333330B",
@@ -73,6 +75,8 @@ U = {
     "BF_OVERVIEW":          "33333333333333333333331B",
     "BF_RECOVERY":          "33333333333333333333331C",
     "BF_LASTWEIGHT":        "33333333333333333333331D",
+    "BF_EXERCISE_PROGRESSION": "33333333333333333333331E",
+    "BF_WORKOUT_DETAIL":       "33333333333333333333331F",
 }
 
 # ---------------------------------------------------------------------------
@@ -98,7 +102,9 @@ SWIFT_FILES = [
     ("BF_HIKE",          "FR_HIKE",          "WorkoutMD/Views/HikeSessionView.swift",   "HikeSessionView.swift"),
     ("BF_OVERVIEW",      "FR_OVERVIEW",      "WorkoutMD/Views/OverviewView.swift",      "OverviewView.swift"),
     ("BF_RECOVERY",      "FR_RECOVERY",      "WorkoutMD/Views/RecoverySessionView.swift","RecoverySessionView.swift"),
-    ("BF_LASTWEIGHT",    "FR_LASTWEIGHT",    "WorkoutMD/Models/LastWeight.swift",         "LastWeight.swift"),
+    ("BF_LASTWEIGHT",    "FR_LASTWEIGHT",    "WorkoutMD/Models/LastWeight.swift",             "LastWeight.swift"),
+    ("BF_EXERCISE_PROGRESSION", "FR_EXERCISE_PROGRESSION", "WorkoutMD/Views/ExerciseProgressionView.swift", "ExerciseProgressionView.swift"),
+    ("BF_WORKOUT_DETAIL",       "FR_WORKOUT_DETAIL",       "WorkoutMD/Views/WorkoutDetailView.swift",        "WorkoutDetailView.swift"),
 ]
 
 def pbxproj():


### PR DESCRIPTION
Closes #10

## Summary

- **`ExerciseProgressionView`** (new) — sheet that scans all saved workout files, extracts the max weight per session for a named exercise, and plots it with Swift Charts (`LineMark` + `PointMark`). Shows a `ContentUnavailableView` when no numeric weight data exists yet.
- **`WorkoutDetailView`** (new) — pushed from the Overview history list; shows each exercise as a section with its logged sets. Tapping an exercise name opens the progression chart sheet.
- **`MarkdownParser`** — new `ParsedSet` struct and `parseSets(from:forExercise:)` method for reading saved workout files. The existing `parseTemplate` only handled template format; this handles the `- [x] 135 × 8` set format in completed files.
- **`ExerciseCardView`** — exercise name in the section header is now a tappable `Button` (`.plain` style, visually unchanged) that opens the progression chart during a live session.
- **`OverviewView`** — each history row is now wrapped in a `NavigationLink` to `WorkoutDetailView`.
- **`generate_xcodeproj.py`** — two new files registered + project regenerated.
- **`README`** — updated to reflect current file structure, full architecture diagram, data flow walkthroughs, and all file formats.

## Test plan

- [ ] Home tab → pick a template → start session → tap an exercise name in the section header → progression chart sheet opens (empty until a workout is saved)
- [ ] Save a workout → start the same session again → tap exercise name → at least one data point appears on the chart
- [ ] Overview tab → tap a past workout row → `WorkoutDetailView` pushes with the workout's exercises and set log
- [ ] In `WorkoutDetailView` → tap an exercise name → progression chart sheet opens with history
- [ ] Bodyweight-only exercises show `"No weight data"` empty state in the chart (no numeric weights to plot)
- [ ] Back navigation works correctly from both `WorkoutDetailView` and the chart sheet

🤖 Generated with [Claude Code](https://claude.com/claude-code)